### PR TITLE
Fix: Vocabulary not fitted or provided

### DIFF
--- a/ML Pipeline Preparation.ipynb
+++ b/ML Pipeline Preparation.ipynb
@@ -1518,7 +1518,7 @@
     }
    ],
    "source": [
-    "y_pred = pipeline.predict(X_test)\n",
+    "y_pred = cv.predict(X_test)\n",
     "print(\"Best Parameters:\", cv.best_params_)\n",
     "print(classification_report(Y_test, y_pred, target_names=category_names))"
    ]
@@ -2124,7 +2124,7 @@
     }
    ],
    "source": [
-    "y_pred2 = pipeline2.predict(X_test)\n",
+    "y_pred2 = cv2.predict(X_test)\n",
     "print(\"Best Parameters:\", cv2.best_params_)\n",
     "print(classification_report(Y_test, y_pred2, target_names=category_names))"
    ]


### PR DESCRIPTION
The issue is that you are fitting a gridsearchcv object and trying to predict using the pipeline object, which was not fitted. 